### PR TITLE
Removed field that was causing an error in version 8.2

### DIFF
--- a/CAT/CATTool.cs
+++ b/CAT/CATTool.cs
@@ -51,7 +51,7 @@ namespace Rappen.XTB.CAT
         public QueryExpression GetActionQuery(Guid solutionid)
         {
             var qx = new QueryExpression("workflow");
-            qx.ColumnSet.AddColumns("name", "uniquename", "createdby", "primaryentity", "scope", "mode", "ismanaged", "iscustomizable", "istransacted", "iscustomprocessingstepallowedforotherpublishers", "inputparameters", "description");
+            qx.ColumnSet.AddColumns("name", "uniquename", "createdby", "primaryentity", "scope", "mode", "ismanaged", "iscustomizable", "istransacted", "inputparameters", "description");
             qx.AddOrder("ismanaged", OrderType.Descending);
             qx.AddOrder("name", OrderType.Ascending);
             qx.Criteria.AddCondition("category", ConditionOperator.Equal, 3);


### PR DESCRIPTION
The field "iscustomprocessingstepallowedforotherpublishers" does not exist in the 8.2 schema. Removing this from the ColumnSet allows the tool to work in legacy systems.